### PR TITLE
initial implementation of run command

### DIFF
--- a/src/Mongo.jl
+++ b/src/Mongo.jl
@@ -5,7 +5,7 @@ module Mongo
 using BSON
 
 export UPSERT, MULTI,
-       find, find_one, count, update, insert, remove, run_cmd
+       find, find_one, count, update, insert, remove, run_command
 
 const MONGO_LIB = "libmongoc"
 const MONGO_OK = 0
@@ -18,19 +18,11 @@ const MULTI = convert(Int, 0x2)
 include("mongo_client.jl")
 include("mongo_cursor.jl")
 
-# run_cmd(), cmd is the name of the command to run,
-# the named arguments passed in args are the options for the command
-# Ex.
-#       run_cmd(client, "db", "collStats", "fs.files", scale=1024)
-
-function run_cmd(client::MongoClient, dbname::String,
-                 cmd::String, val::Any=1; args...)
-    ops = {string(arg[1]) => arg[2] for arg in args}
-    fcmd = BSONObject(merge!({cmd => val}, ops))
+function run_command(client::MongoClient, dbname::String, command::BSONObject)
     bson = BSONObject()
     errno = ccall((:mongo_run_command, MONGO_LIB), Int32,
                   (Ptr{Void}, Ptr{Uint8}, Ptr{Void}, Ptr{Void}),
-                  client._mongo, bytestring(dbname), fcmd._bson, bson._bson)
+                  client._mongo, bytestring(dbname), command._bson, bson._bson)
     errno == MONGO_ERROR ? nothing : bson
 end
 

--- a/src/Mongo.jl
+++ b/src/Mongo.jl
@@ -5,7 +5,7 @@ module Mongo
 using BSON
 
 export UPSERT, MULTI,
-       find, find_one, count, update, insert, remove
+       find, find_one, count, update, insert, remove, run_cmd
 
 const MONGO_LIB = "libmongoc"
 const MONGO_OK = 0
@@ -18,6 +18,21 @@ const MULTI = convert(Int, 0x2)
 include("mongo_client.jl")
 include("mongo_cursor.jl")
 
+# run_cmd(), cmd is the name of the command to run,
+# the named arguments passed in args are the options for the command
+# Ex.
+#       run_cmd(client, "db", "collStats", "fs.files", scale=1024)
+
+function run_cmd(client::MongoClient, dbname::String,
+                 cmd::String, val::Any=1; args...)
+    ops = {string(arg[1]) => arg[2] for arg in args}
+    fcmd = BSONObject(merge!({cmd => val}, ops))
+    bson = BSONObject()
+    errno = ccall((:mongo_run_command, MONGO_LIB), Int32,
+                  (Ptr{Void}, Ptr{Uint8}, Ptr{Void}, Ptr{Void}),
+                  client._mongo, bytestring(dbname), fcmd._bson, bson._bson)
+    errno == MONGO_ERROR ? nothing : bson
+end
 
 function find(client::MongoClient, namespace::String, query::BSONObject, fields::BSONObject, limit::Int, skip::Int)
     MongoCursor(client, namespace, query, fields, limit, skip)
@@ -25,7 +40,6 @@ end
 find(client::MongoClient, namespace::String, query::BSONObject, fields::BSONObject) = find(client, namespace, query, fields, 0, 0)
 find(client::MongoClient, namespace::String, query::BSONObject) = find(client, namespace, query, BSONObject(), 0, 0)
 find(client::MongoClient, namespace::String) = find(client, namespace, BSONObject(), BSONObject(), 0, 0)
-
 
 function find_one(client::MongoClient, namespace::String, query::BSONObject, fields::BSONObject)
     bson = BSONObject()


### PR DESCRIPTION
Hi, I am eventually going to be using this Mongo library in the future and thought I would contribute some. 

This is my initial implementation of the run command, which is similar to the PyMongo implementation (http://api.mongodb.org/python/current/api/pymongo/database.html).

An example of use would be:

``` julia
run_cmd(client, "test", "collstats", "collection"; scale=1024)
```

This of course will return a BSONObject with the results of the command or nothing on error
It runs the command collstats on collection in the test database with the argument scale = 1024. 

The above shows how to pass arguments to a command, you simply add a named argument to the function call.

To run a command that doesn't require a value:

``` julia
run_cmd(client, "test", "isMaster")
```
